### PR TITLE
Update IntroState.cpp

### DIFF
--- a/FlumenBattle/Intro/IntroState.cpp
+++ b/FlumenBattle/Intro/IntroState.cpp
@@ -1,13 +1,33 @@
 #include "IntroState.h"
 #include "FlumenBattle/PreGame/PreGameState.h"
-//#include "FlumenBattle/PreGame/PreGameController.h"
 
-namespace intro
-{
-    void IntroState::HandleEnter()
-    {
-        pregame::PreGameState::Get()->Enter();
-    }
+/**
+ * @file IntroState.cpp
+ * @brief Implements the introductory state of the game logic, 
+ * transitioning to the pre-game phase upon entry.
+ */
 
-    void IntroState::HandleExit() {}
+namespace intro {
+
+/**
+ * @brief Called when entering the IntroState.
+ * 
+ * This function initiates the transition to the PreGameState. The actual
+ * business logic for entering the pre-game portion is deferred to the
+ * PreGameState class.
+ */
+void IntroState::HandleEnter() {
+    // Transition immediately to PreGameState
+    pregame::PreGameState::Get()->Enter();
 }
+
+/**
+ * @brief Called when exiting the IntroState.
+ * 
+ * Currently, no additional cleanup is required for exiting this state.
+ */
+void IntroState::HandleExit() {
+    // No specialized logic on exit
+}
+
+} // namespace intro


### PR DESCRIPTION
Below is a clean, concise, and well-documented version of the IntroState.cpp implementation. It includes the original logic for transitioning from the IntroState to PreGameState, while clarifying the structure and purpose in code comments. This ensures maintainability and readability.

Explanation
Header Includes

We include the local header IntroState.h to declare the class methods. We also include FlumenBattle/PreGame/PreGameState.h so we can call PreGameState::Get()->Enter(). Namespace

The IntroState methods are wrapped in the intro namespace, matching the structure indicated in the original code. Documentation

Each method has a doxygen-style comment, briefly explaining what it does. We also have a file-level comment describing the purpose of IntroState.cpp. Functionality

HandleEnter() triggers the transition to the next state (PreGameState). HandleExit() remains empty, indicating we don’t need additional teardown logic when leaving the intro state. This final code offers a clear layout for future modifications, better readability, and straightforward logic for the introductory portion of the game flow.